### PR TITLE
WIP: Handle external URLs on Android

### DIFF
--- a/Information/InformationScreen.js
+++ b/Information/InformationScreen.js
@@ -5,7 +5,7 @@ import { Icon } from 'react-native-elements';
 import { StackNavigator } from 'react-navigation';
 import Mailer from 'react-native-mail';
 import DeviceInfo from 'react-native-device-info';
-import SafariView from 'react-native-safari-view';
+import { handleExternalUrl } from '../components/Browser';
 
 export default class InformationScreen extends React.Component {
   static navigationOptions = {
@@ -80,19 +80,7 @@ export default class InformationScreen extends React.Component {
   }
 
   openLink(url) {
-    SafariView.isAvailable()
-    .then(SafariView.show({
-      url: url
-		}))
-		.catch((err) => {
-			Linking.canOpenURL(url).then(supported => {
-				if (!supported) {
-					console.log(`Can't handle url: ${url}`);
-				} else {
-					return Linking.openURL(url);
-				}
-			}).catch(err => console.error('An error occurred', err));
-    });
+    handleExternalUrl(url);
   }
 
   showCodeOfConduct = () => {

--- a/Information/OrganizersScreen.js
+++ b/Information/OrganizersScreen.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyleSheet, Text, View, Button, SectionList, Image, TouchableOpacity, Linking } from 'react-native';
 import { TabNavigator } from 'react-navigation';
 import { StackNavigator } from 'react-navigation';
-import SafariView from 'react-native-safari-view';
+import { handleExternalUrl } from '../components/Browser';
 
 export default class VenueInformationScreen extends React.Component {
   static navigationOptions = ({navigation}) => {
@@ -60,19 +60,7 @@ export default class VenueInformationScreen extends React.Component {
 
   openTwitter(item) {
 		const url = `https://twitter.com/${item.twitter}`;
-		SafariView.isAvailable()
-    .then(SafariView.show({
-      url: url
-		}))
-		.catch((err) => {
-			Linking.canOpenURL(url).then(supported => {
-				if (!supported) {
-					console.log(`Can't handle url: ${url}`);
-				} else {
-					return Linking.openURL(url);
-				}
-			}).catch(err => console.error('An error occurred', err));
-		});
+		handleExternalUrl(url);
   }
 
   renderSpeaker(item) {

--- a/News/NewsScreen.js
+++ b/News/NewsScreen.js
@@ -4,7 +4,7 @@ import { TabNavigator } from 'react-navigation';
 import { StackNavigator } from 'react-navigation';
 import ActionSheet from 'react-native-actionsheet';
 import SegmentedControlTab from 'react-native-segmented-control-tab';
-import SafariView from 'react-native-safari-view';
+import { handleExternalUrl } from '../components/Browser';
 const ApiClient = require('../api/ApiClient');
 const client = new ApiClient();
 
@@ -107,9 +107,7 @@ export default class NewsScreen extends React.Component {
     } else if (i == 2) {
       url = 'https://twitter.com/hashtag/appbuilders18';
     }
-    SafariView.isAvailable().then(SafariView.show({
-      url: url
-    }));
+    handleExternalUrl(url);
   }
 
   render() {

--- a/Sponsors/SponsorsScreen.js
+++ b/Sponsors/SponsorsScreen.js
@@ -3,7 +3,7 @@ import { StyleSheet, Text, View, SafeAreaView, Button, Image, ScrollView, Toucha
 import { TabNavigator } from 'react-navigation';
 import { Icon } from 'react-native-elements';
 import { StackNavigator } from 'react-navigation';
-import SafariView from 'react-native-safari-view';
+import { handleExternalUrl } from '../components/Browser';
 
 class Sponsors extends React.Component {
 
@@ -29,19 +29,7 @@ class Sponsors extends React.Component {
   }
 
   openLink(url) {
-    SafariView.isAvailable()
-    .then(SafariView.show({
-      url: url
-		}))
-		.catch((err) => {
-			Linking.canOpenURL(url).then(supported => {
-				if (!supported) {
-					console.log(`Can't handle url: ${url}`);
-				} else {
-					return Linking.openURL(url);
-				}
-			}).catch(err => console.error('An error occurred', err));
-    });
+    handleExternalUrl(url);
   }
 
   _onPress(sponsor) {

--- a/components/Browser.android.js
+++ b/components/Browser.android.js
@@ -1,0 +1,7 @@
+import { Linking, ToastAndroid } from 'react-native';
+
+export const handleExternalUrl = url =>  
+    Linking.canOpenURL(url)
+            .then(supported => supported && Linking.openURL(url))
+            // todo: show error toast or snackbar
+            .catch(err => ToastAndroid.show(`Your device can't handle this link :(`, ToastAndroid.SHORT));

--- a/components/Browser.ios.js
+++ b/components/Browser.ios.js
@@ -1,0 +1,4 @@
+import SafariView from 'react-native-safari-view';
+
+export const handleExternalUrl = url =>  
+    SafariView.isAvailable().then(SafariView.show({ url }));


### PR DESCRIPTION
External URLs are handled with a `Browser` abstraction:

- On iOS, urls are explicitly open with a `SafariView`;
- On Android, we let the user choose the appropriate app by using the native `Linking` feature.

Scenarios tested:

- Android device without twitter app: twitter links are opened in browser (OS asks the preferred one once);
- Android device with twitter app: links are opened in the twitter app.

Scenarios to test:

- No regressions on iOS (unfortunately I can't run the app since I can't compile it). @BalestraPatrick, if you test that everything still works on iOS I'll remove the WIP flag from the PR.

This PR closes #9.