### PR TITLE
Fix venue location screen crash on Android

### DIFF
--- a/Information/VenueLocationScreen.js
+++ b/Information/VenueLocationScreen.js
@@ -59,11 +59,12 @@ export default class VenueInformationScreen extends React.Component {
             <MapView
               style={styles.map}
               initialRegion={{
-              latitude: 46.005063,
-              longitude: 8.956442,
-              latitudeDelta: 0.005,
-              longitudeDelta: 0.005
-              }}>
+                latitude: 46.005063,
+                longitude: 8.956442,
+                latitudeDelta: 0.005,
+                longitudeDelta: 0.005
+              }}
+            >
               <MapView.Marker.Animated ref={marker => { this.marker = marker }} coordinate={this.state.coordinate}/>
             </MapView>
         	</View>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,9 +12,6 @@
     <meta-data
         android:name="com.google.firebase.messaging.default_notification_icon"
         android:resource="@mipmap/ic_stat_ic_notification" />
-    <meta-data
-        android:name="com.google.android.geo.API_KEY"
-        android:value="AIzaSyBdAbDTbMqtmu3JK_e54hxdx20misWp7J4" />
 
     <uses-sdk
         android:minSdkVersion="16"
@@ -27,6 +24,11 @@
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme"
       android:launchMode="singleTop">
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="AIzaSyBdAbDTbMqtmu3JK_e54hxdx20misWp7J4" />
+
         <service
             android:name="io.invertase.firebase.messaging.MessagingService"
             android:enabled="true"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
     <meta-data
         android:name="com.google.firebase.messaging.default_notification_icon"
         android:resource="@mipmap/ic_stat_ic_notification" />
+    <meta-data
+        android:name="com.google.android.geo.API_KEY"
+        android:value="AIzaSyBdAbDTbMqtmu3JK_e54hxdx20misWp7J4" />
+
     <uses-sdk
         android:minSdkVersion="16"
         android:targetSdkVersion="22" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,5 +24,11 @@ allprojects {
         maven {
             url 'https://maven.google.com'
         }
+        configurations.all {
+            resolutionStrategy {
+                force "com.google.android.gms:play-services-gcm:11.6.0"
+            }
+        }
+   
     }
 }


### PR DESCRIPTION
On Android, the venue location screen crashed because of the lack of API key to access Google Maps when displaying the `MapView`.

This PR fixes the issue.